### PR TITLE
[Fix] Config server data fetch and eureka server application.yml configuration 

### DIFF
--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -8,11 +8,24 @@
 		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.hermes</groupId>
-	<artifactId>config-server</artifactId>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>config-server</name>
-	<description>Helpdesk config server</description>
+	<name>demo</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
 	<properties>
 		<java.version>21</java.version>
 		<spring-cloud.version>2024.0.0</spring-cloud.version>
@@ -27,12 +40,6 @@
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -53,18 +60,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.springframework.boot</groupId>
-							<artifactId>spring-boot-configuration-processor</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/config-server/src/main/java/com/hermes/config_server/ConfigServerApplication.java
+++ b/config-server/src/main/java/com/hermes/config_server/ConfigServerApplication.java
@@ -2,10 +2,13 @@ package com.hermes.config_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.config.server.EnableConfigServer;
 
-@EnableConfigServer
+
 @SpringBootApplication
+@EnableConfigServer
+@EnableDiscoveryClient
 public class ConfigServerApplication {
 
 	public static void main(String[] args) {

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -1,10 +1,9 @@
 server:
-  port: 8888
+  port: 8181
 
 spring:
   application:
     name: config-server
-
   cloud:
     config:
       server:
@@ -12,8 +11,3 @@ spring:
           uri: https://github.com/J0aoPaulo/hermes-config
           username: ${GIT_USERNAME}
           password: ${GIT_PASSWORD}
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -8,27 +8,43 @@
 		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.hermes</groupId>
-	<artifactId>eureka-server</artifactId>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>eureka-server</name>
-	<description>Helpdesk system with microservices</description>
+	<name>demo</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
 	<properties>
 		<java.version>21</java.version>
 		<spring-cloud.version>2024.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-config-client -->
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-config-client</artifactId>
-			<version>4.2.0</version>
-		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/eureka-server/src/main/resources/application.yml
+++ b/eureka-server/src/main/resources/application.yml
@@ -1,8 +1,13 @@
+server:
+  port: 8761
+
 spring:
   application:
     name: eureka-server
-  config:
-    import: "configserver:"
-  cloud:
-    config:
-      uri: http://localhost:8888
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    serviceUrl:
+      defaultZone: http://localhost:8761/


### PR DESCRIPTION
## Description

This pull request includes several changes to the configuration and dependencies of the `config-server` and `eureka-server`. The most important changes are grouped by theme below.

### Configuration changes:

- [x]  [`config-server/src/main/resources/application.yml`](diffhunk://#diff-6c199fa8c301bc2d9946e9273d287c42c97424ea6a28a644bef49a181c61acfeL2-L19): Changed the server port from `8888` to `8181` and removed the `eureka` client configuration.
- [x] [`eureka-server/src/main/resources/application.yml`](diffhunk://#diff-b0671879f54ae835da3809fdcd082017879122d05fa8d342c0201d71697ca8d6R1-R13): Added server port configuration and updated the `eureka` client settings to disable registration and fetching registry.

### Code updates:

- [x] [`config-server/src/main/java/com/hermes/config_server/ConfigServerApplication.java`](diffhunk://#diff-b9285cc8ed34d84d8954332fced47a2b844687b3918955cd977d163ec7f3f5d8R5-R11): Added `@EnableDiscoveryClient` annotation to enable service discovery.
